### PR TITLE
Fix - Handle dismissed notifications

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,6 +28,7 @@
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <activity android:name="com.adobe.phonegap.push.PushHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.PushHandlerActivity"/>
       <receiver android:name="com.adobe.phonegap.push.BackgroundActionButtonHandler"/>
+      <receiver android:name="com.adobe.phonegap.push.PushDismissedHandler"/>
       <service android:name="com.adobe.phonegap.push.FCMService">
         <intent-filter>
           <action android:name="com.google.firebase.MESSAGING_EVENT"/>
@@ -51,6 +52,7 @@
     <source-file src="src/android/com/adobe/phonegap/push/PushPlugin.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PermissionUtils.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java" target-dir="src/com/adobe/phonegap/push/"/>
+    <source-file src="src/android/com/adobe/phonegap/push/PushDismissedHandler.java" target-dir="src/com/adobe/phonegap/push/"/>
     <lib-file src="src/android/notification-hubs-android-sdk-0.4.jar" />
   </platform>
   <platform name="ios">

--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -365,11 +365,14 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
         int requestCode = new Random().nextInt();
         PendingIntent contentIntent = PendingIntent.getActivity(this, requestCode, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        Intent dismissedNotificationIntent = new Intent(notificationIntent);
+        Intent dismissedNotificationIntent = new Intent(this, PushDismissedHandler.class);
+        dismissedNotificationIntent.putExtra(PUSH_BUNDLE, extras);
+        dismissedNotificationIntent.putExtra(NOT_ID, notId);
         dismissedNotificationIntent.putExtra(DISMISSED, true);
+        dismissedNotificationIntent.setAction(PUSH_DISMISSED);
 
         requestCode = new Random().nextInt();
-        PendingIntent deleteIntent = PendingIntent.getActivity(this, requestCode, dismissedNotificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent deleteIntent = PendingIntent.getBroadcast(this, requestCode, dismissedNotificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 
         NotificationCompat.Builder mBuilder = null;
 

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -85,7 +85,7 @@ public interface PushConstants {
     public static final String SUBJECT = "subject";
     public static final String GOOGLE_APP_ID = "google_app_id";
     public static final String GCM_DEFAULT_SENDER_ID = "gcm_defaultSenderId";
-
+    public static final String PUSH_DISMISSED = "push_dismissed";
     public static final String DEFAULT_CHANNEL_ID = "PushPluginChannel";
     public static final String CHANNEL_ID = "id";
     public static final String CHANNEL_DESCRIPTION = "description";

--- a/src/android/com/adobe/phonegap/push/PushDismissedHandler.java
+++ b/src/android/com/adobe/phonegap/push/PushDismissedHandler.java
@@ -1,0 +1,25 @@
+package com.adobe.phonegap.push;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+public class PushDismissedHandler extends BroadcastReceiver implements PushConstants {
+    private static String LOG_TAG = "Push_DismissedHandler";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Bundle extras = intent.getExtras();
+        FCMService fcm = new FCMService();
+        String action = intent.getAction();
+        int notID = intent.getIntExtra(NOT_ID, 0);
+
+        if (action.equals(PUSH_DISMISSED)) {
+            Log.d(LOG_TAG, "PushDismissedHandler = " + extras);
+            Log.d(LOG_TAG, "not id = " + notID);
+
+            fcm.setNotification(notID, "");
+        }
+    }
+}


### PR DESCRIPTION
## Description
There was a problem with dismissing notification when application was in the background. When someone cleared notifications, the application started automatically. Dismissed notification was handled in a wrong way by code from phonegap-plugin-push. This pull request resolves the problem.

## Related Issue
phonegap-plugin-push issue: https://github.com/phonegap/phonegap-plugin-push/issues/1665

## Solution
I added code from pull request to phonegap-plugin-push: https://github.com/phonegap/phonegap-plugin-push/pull/1816 and https://github.com/phonegap/phonegap-plugin-push/commit/118b1a454eebc9e5b053f40be3f1a3af253d783e
